### PR TITLE
feat: add a11y plugin

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -10,6 +10,7 @@ const config: StorybookConfig = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
+    '@storybook/addon-a11y',
   ],
   typescript: {
     check: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@commitlint/config-conventional": "^19.8.1",
         "@eslint/js": "^9.9.1",
         "@playwright/test": "^1.55.0",
+        "@storybook/addon-a11y": "^9.1.8",
         "@storybook/addon-actions": "^9.0.8",
         "@storybook/addon-essentials": "^9.0.0-alpha.12",
         "@storybook/addon-interactions": "^9.0.0-alpha.10",
@@ -3586,6 +3587,24 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "9.1.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-9.1.8.tgz",
+      "integrity": "sha512-7I+Ll29aBwgAbpkNpK+BBJ+BmMCS7+Qe8fPh1n4701Hx7FB+laAx8UP+3kbmqCOwCvLU5JU5KJKgUMMGVE/Jww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "axe-core": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^9.1.8"
+      }
     },
     "node_modules/@storybook/addon-actions": {
       "version": "9.0.8",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@commitlint/config-conventional": "^19.8.1",
     "@eslint/js": "^9.9.1",
     "@playwright/test": "^1.55.0",
+    "@storybook/addon-a11y": "^9.1.8",
     "@storybook/addon-actions": "^9.0.8",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",


### PR DESCRIPTION
This pull request adds accessibility testing support to Storybook by including the `@storybook/addon-a11y` addon in both the configuration and dependencies.

Accessibility improvements:

* Added `@storybook/addon-a11y` to the `addons` array in `.storybook/main.ts` to enable accessibility checks in Storybook.
* Added `@storybook/addon-a11y` as a development dependency in `package.json` to ensure the addon is installed.

**Testing**:

1. Go to [review app](https://kapwa-git-review-featadd-storybook-a11y-adobocorp.vercel.app/storybook/index.html?path=/story/components-banner--default)
2. Click a component, ie: Banner
3. Click accessibility tab on the bottom
<img width="428" height="276" alt="Screenshot 2025-09-29 at 9 37 04 AM" src="https://github.com/user-attachments/assets/5a85037b-7385-4bbe-a058-c9587b84e62e" />
