### PR TITLE
docs: add local dev setup and clarify contribution workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,11 +30,10 @@
       <a href="#contribution-workflow">Contribution Workflow</a>
       <ul>
         <li><a href="#fork-and-clone-repositories">Fork and clone repositories</a></li>
+        <li><a href="#sync-often">Sync often</a></li>
         <li><a href="#commit-messages">Commit messages</a></li>
-        <li><a href="#commit-messages">Branch creation</a></li>
-        <li><a href="#commit-messages">Pull requests</a></li>
-        <li><a href="#commit-messages">Commit messages</a></li>
-        <li><a href="#commit-messages">Commit messages</a></li>
+        <li><a href="#branch-creation">Branch creation</a></li>
+        <li><a href="#pull-requests">Pull requests</a></li>
       </ul>
     </li>
     <li><a href="#resources">Resources</a></li>
@@ -162,27 +161,43 @@ Read our {name and link to your style guide} to understand our guidelines for wr
 
 ### Fork and clone repositories
 
-To contribute, first fork the repository to your own GitHub account, then clone your fork to your local machine.
+To contribute, first fork the repository to your own GitHub account, then clone your fork to your local machine:
+
+```sh
+git clone git@github.com:<your-github-username>/kapwa.git
+cd kapwa
+```
+
+After cloning your fork, add the main Kapwa repository as `upstream`:
+
+```sh
+git remote add upstream git@github.com:bettergovph/kapwa.git
+git remote -v
+```
+
+You should now have:
+
+- `origin` pointing to your fork
+- `upstream` pointing to the main Kapwa repository
 
 Follow this guide for step-by-step instructions:
 [Fork a repository][forking]
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
-### Report issues and bugs
+### Sync often
 
-If you encounter a problem with the project, please open an issue in this [repository][issues].
+Pull the latest updates from the main repository often, especially before starting new work and before opening a pull request:
 
-When reporting an issue, please include the following details to help us investigate:
+```sh
+git checkout main
+git pull upstream main
+git push origin main
+```
 
-- Description – A clear and concise explanation of the problem.
-- Steps to reproduce – How to reproduce the issue (step by step).
-- Expected behavior – What you thought should happen.
-- Actual behavior – What actually happened instead.
-- Environment details – Your operating system, browser (if applicable), Node.js version, etc.
-- Screenshots or logs – If relevant, add screenshots or error logs.
+This keeps your forked `main` branch current with the original repository.
 
-> Tip: Check existing issues before creating a new one to avoid duplicates.
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ### Commit messages
 
@@ -217,6 +232,14 @@ docs: add CONTRIBUTING.md and CODE_OF_CONDUCT.md
 
 ### Branch creation
 
+Create your working branch from your synced `main` branch:
+
+```sh
+git checkout main
+git pull upstream main
+git checkout -b fix/short-description
+```
+
 We follow a prefix-based branch naming convention for clarity:
 
 #### Format
@@ -241,27 +264,35 @@ docs/add-contributing-and-code-of-conduct
 
 We use Pull Requests (PRs) to review and merge changes. Follow these steps when creating a PR:
 
-1. Fork the repository and create a branch based on the type of work (feature/, fix/, docs/, etc.).
+1. Fork the repository and create a branch from your synced `main`.
 2. Make your changes and ensure your code passes linting and tests.
 3. Commit your changes following the Conventional Commits
    standard.
 4. Push your branch to your forked repository:
    ```sh
-   git push origin <branch-name>
+   git push -u origin <branch-name>
    ```
 5. Open a Pull Request to the main repository:
 
-- Target the main branch (or the branch specified by maintainers).
+- Target `bettergovph/kapwa:main` unless maintainers specify a different base branch.
 - Provide a clear title and detailed description of your changes.
 - Reference any related issues (e.g., Closes #12).
 
-6. Wait for review:
+6. If `main` moves while your PR is open, update your branch with the latest upstream changes:
+
+   ```sh
+   git checkout <branch-name>
+   git pull upstream main
+   git push origin <branch-name>
+   ```
+
+7. Wait for review:
 
 - Maintain open communication with reviewers.
 
-- Make any requested changes by committing to the same branch—the PR will update automatically.
+- Make any requested changes by committing to the same branch. The PR will update automatically.
 
-7. A maintainer will merge your PR once it’s approved.
+8. A maintainer will merge your PR once it’s approved.
    **Do not merge your own PR unless explicitly allowed.**
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Please see our [Contributing Guide](./CONTRIBUTING.md) for details on:
 - Development setup
 - Reporting bugs
 - Opening issues and pull requests
+- Local contributor setup in [docs/LOCAL_DEVELOPMENT.md](./docs/LOCAL_DEVELOPMENT.md)
 
 ## Contributing
 

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -1,0 +1,107 @@
+# Kapwa Local Development Setup
+
+This guide is for contributors who already have the Kapwa repository locally and want to run the demo site, component library, and Storybook on their machine.
+
+For the fork, upstream, sync, and pull request workflow, see [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Prerequisites
+
+- Node.js 18 or newer
+- npm 9 or newer
+- Git
+
+If you use `nvm` or `fnm`, switch to the repo's preferred Node.js version before installing dependencies:
+
+```sh
+nvm use
+```
+
+or
+
+```sh
+fnm use
+```
+
+## 1. Install Dependencies
+
+```sh
+npm install
+```
+
+## 2. Create Your Local `.env`
+
+Create a local `.env` file from `.env.example`:
+
+```sh
+cp .env.example .env
+```
+
+The current required variable is:
+
+```env
+VITE_STORYBOOK_HOST=http://localhost:6006
+```
+
+This is important in development because the demo site's navbar uses `VITE_STORYBOOK_HOST` for the local `Storybook` link. If `.env` is missing, that navbar link will not point to your local Storybook server correctly.
+
+## 3. Start The App
+
+Run both the demo site and Storybook together:
+
+```sh
+npm run dev
+```
+
+This starts:
+
+- the demo site via `npm run start:client`
+- Storybook via `npm run start:storybook`
+
+Default local URLs:
+
+- Demo site: `http://localhost:5173`
+- Storybook: `http://localhost:6006`
+
+## Useful Commands
+
+Run only the demo site:
+
+```sh
+npm run start:client
+```
+
+Run only Storybook:
+
+```sh
+npm run start:storybook
+```
+
+Build the component library:
+
+```sh
+npm run build-lib
+```
+
+Build the demo site:
+
+```sh
+npm run build-site
+```
+
+Build Storybook:
+
+```sh
+npm run build:storybook
+```
+
+Run lint:
+
+```sh
+npm run lint
+```
+
+## Notes
+
+- `npm run dev` is the easiest way to verify the demo site and Storybook together.
+- `npm run build-lib` also regenerates component exports after the library build.
+- If you are checking navbar links locally, make sure Storybook is running and `.env` exists before assuming the link is broken.


### PR DESCRIPTION
## Summary

Improve contributor onboarding docs to make Kapwa easier for beginners to set up and contribute to.

## Why

New contributors can miss important setup and Git workflow steps, especially around local development and keeping a fork synced with the main repository. This update makes the project more beginner-friendly by separating local setup from contribution workflow and documenting the expected fork → sync → branch → PR flow more clearly.

## What Changed

- Added a dedicated local development guide in `docs/LOCAL_DEVELOPMENT.md`
- Updated `README.md` to point contributors to the local setup guide
- Refined the `Contribution workflow` section in `CONTRIBUTING.md` to clarify:
  - forking the repo
  - adding `upstream`
  - syncing with the main repo
  - creating branches from updated `main`
  - opening PRs from a fork back to `main`

## Impact

This should reduce setup confusion for first-time contributors and make the expected contribution flow easier to follow.